### PR TITLE
refactor: syntactic cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,9 +49,38 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
+name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bitvec"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
+dependencies = [
+ "crypto-mac",
+ "digest",
+ "opaque-debug",
+]
 
 [[package]]
 name = "block-buffer"
@@ -53,9 +100,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a7111f797cc721407885a323fb071636aee57f750b1a4ddc27397eba168a74"
+checksum = "18dda7dc709193c0d86a1a51050a926dc3df1cf262ec46a23a25dba421ea1924"
 dependencies = [
  "borsh-derive",
  "hashbrown 0.9.1",
@@ -63,22 +110,22 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307f3740906bac2c118a8122fe22681232b244f1369273e45f1156b45c43d2dd"
+checksum = "684155372435f578c0fa1acd13ebbb182cc19d6b38b64ae7901da4393217d264"
 dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
- "proc-macro-crate",
+ "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn",
 ]
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2104c73179359431cc98e016998f2f23bc7a05bc53e79741bcba705f30047bc"
+checksum = "2102f62f8b6d3edeab871830782285b64cc1830168094db05c8e458f209bc5c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -87,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae29eb8418fcd46f723f8691a2ac06857d31179d33d2f2d91eb13967de97c728"
+checksum = "196c978c4c9b0b142d446ef3240690bf5a8a33497074a113ff9a337ccb750483"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -103,10 +150,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c751592b77c499e7bce34d99d67c2c11bdc0574e9a488ddade14150a4698"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytesize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
+name = "c2-chacha"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27dae93fe7b1e0424dc57179ac396908c26b035a87234809f5c4dfd1b47dc80"
+dependencies = [
+ "cipher",
+ "ppv-lite86",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -121,6 +196,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +231,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+dependencies = [
+ "byteorder",
+ "digest",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -158,6 +285,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "easy-ext"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53aff6fdc1b181225acdcb5b14c47106726fd8e486707315b1b138baed68ee31"
+
+[[package]]
+name = "ed25519"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.4",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +349,28 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -187,6 +393,37 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "indexmap"
@@ -223,6 +460,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,26 +478,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
-name = "near-contract-standards"
-version = "3.2.0"
+name = "near-account-id"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7421d0a5c7aeb57b37a0cf3a71a7aefbbdc7727f9811d9dd86fa55e4f0de4d3"
+checksum = "4cd61f43cedc1bb7a7c097ef3adbab0092a51185dca0e48d5851b37818e13978"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "near-contract-standards"
+version = "4.0.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4844414401d8882c2217827ed4fd11f6370a1186ac8a9e8073fe23287a266851"
 dependencies = [
  "near-sdk",
 ]
 
 [[package]]
-name = "near-primitives-core"
-version = "0.4.0"
+name = "near-crypto"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b3fb5acf3a494aed4e848446ef2d6ebb47dbe91c681105d4d1786c2ee63e52"
+checksum = "f68d8d55bd2a457eba5956d8c1255e288c47f394ca6fffe6184d19664bf0bc4c"
 dependencies = [
- "base64",
+ "arrayref",
+ "blake2",
+ "borsh",
+ "bs58",
+ "c2-chacha",
+ "curve25519-dalek",
+ "derive_more",
+ "ed25519-dalek",
+ "lazy_static",
+ "libc",
+ "near-account-id",
+ "parity-secp256k1",
+ "primitive-types",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "serde",
+ "serde_json",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
+name = "near-primitives"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d93aaf84ad4f5ccf780d8a0029c6fb636a2e6c1ddb3c772dee4686529e30a8"
+dependencies = [
+ "base64 0.13.0",
+ "borsh",
+ "bs58",
+ "byteorder",
+ "bytesize",
+ "chrono",
+ "derive_more",
+ "easy-ext",
+ "hex",
+ "near-crypto",
+ "near-primitives-core",
+ "near-rpc-error-macro",
+ "near-vm-errors",
+ "num-rational",
+ "primitive-types",
+ "rand 0.7.3",
+ "reed-solomon-erasure",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smart-default",
+ "validator",
+]
+
+[[package]]
+name = "near-primitives-core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d88b2b0f418c1174214fb51106c90251f61ecfe4c7063f149c2e199ec2850fd"
+dependencies = [
+ "base64 0.11.0",
  "borsh",
  "bs58",
  "derive_more",
  "hex",
  "lazy_static",
+ "near-account-id",
  "num-rational",
  "serde",
  "serde_json",
@@ -263,22 +575,21 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "0.1.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa8dbf8437a28ac40fcb85859ab0d0b8385013935b000c7a51ae79631dd74d9"
+checksum = "4a98c9bd7edee4dcfc293e3511e9fab826bcd6fbfbfe06124a1164b94ee60351"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "serde_json",
  "syn",
 ]
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "0.1.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6111d713e90c7c551dee937f4a06cb9ea2672243455a4454cc7566387ba2d9"
+checksum = "1abade92d0fc76a6c25aeb82f3e7fd97678ab5d0fd92b80149a65d1088e86505"
 dependencies = [
  "near-rpc-error-core",
  "proc-macro2",
@@ -289,26 +600,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-runtime-utils"
-version = "4.0.0-pre.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48d80c4ca1d4cf99bc16490e1e3d49826c150dfc4410ac498918e45c7d98e07"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "near-sdk"
-version = "3.1.0"
+version = "4.0.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7383e242d3e07bf0951e8589d6eebd7f18bb1c1fc5fbec3fad796041a6aebd1"
+checksum = "37874b631f47ce76e1fdddeaad8314529384d9d150578fd42ad77b312cf739d6"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "borsh",
  "bs58",
  "near-primitives-core",
  "near-sdk-macros",
+ "near-sys",
  "near-vm-logic",
  "serde",
  "serde_json",
@@ -316,10 +618,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-core"
-version = "3.1.0"
+name = "near-sdk-macros"
+version = "4.0.0-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284a78d9eb8eda58330462fa0023a6d7014c941df1f0387095e7dfd1dc0f2bce"
+checksum = "87ade9707ad0c0b977f524064f4602705e6f49d693a7b106277c13e4e68fe4f9"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -328,42 +630,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-sdk-macros"
-version = "3.1.0"
+name = "near-sys"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2037337438f97d1ce5f7c896cf229dc56dacd5c01142d1ef95a7d778cde6ce7d"
-dependencies = [
- "near-sdk-core",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "f6a7aa3f46fac44416d8a93d14f30a562c4d730a1c6bf14bffafab5f475c244a"
 
 [[package]]
 name = "near-vm-errors"
-version = "4.0.0-pre.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e281d8730ed8cb0e3e69fb689acee6b93cdb43824cd69a8ffd7e1bfcbd1177d7"
+checksum = "e781248bed1f8e4792aee0c0362cf8bc831fc9f51573bc43807b5e07e0e7db81"
 dependencies = [
  "borsh",
  "hex",
+ "near-account-id",
  "near-rpc-error-macro",
  "serde",
 ]
 
 [[package]]
 name = "near-vm-logic"
-version = "4.0.0-pre.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11cb28a2d07f37680efdaf860f4c9802828c44fc50c08009e7884de75d982c5"
+checksum = "9c06b3cb3ccf0423a9ba6908ccf07abe19c3c34319af200c733f34b7ac5af0ab"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "borsh",
  "bs58",
  "byteorder",
+ "near-account-id",
+ "near-crypto",
+ "near-primitives",
  "near-primitives-core",
- "near-runtime-utils",
  "near-vm-errors",
+ "ripemd160",
  "serde",
  "sha2",
  "sha3",
@@ -419,6 +719,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "parity-scale-codec"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+dependencies = [
+ "proc-macro-crate 1.1.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "parity-secp256k1"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fca4f82fccae37e8bbdaeb949a4a218a1bbc485d11598f193d2a908042e5fc1"
+dependencies = [
+ "arrayvec 0.5.2",
+ "cc",
+ "cfg-if 0.1.10",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
 name = "pest"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,11 +772,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "primitive-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+dependencies = [
+ "thiserror",
  "toml",
 ]
 
@@ -455,6 +826,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "reed-solomon-erasure"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +927,23 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "ripemd160"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -562,6 +1036,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "smart-default"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "swt"
 version = "0.1.0"
 dependencies = [
@@ -579,6 +1088,69 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
@@ -602,16 +1174,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "uint"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "validator"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d6937c33ec6039d8071bcf72933146b5bbe378d645d8fa59bdadabfc2a249"
+dependencies = [
+ "idna",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9680608df133af2c1ddd5eaf1ddce91d60d61b6bc51494ef326458365a470a"
+
+[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wee_alloc"
@@ -646,3 +1291,30 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "zeroize"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/swt/Cargo.toml
+++ b/swt/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # near-sdk = { git = "https://github.com/near/near-sdk-rs", rev = "9d99077" }
 # near-contract-standards = { git = "https://github.com/near/near-sdk-rs", rev = "9d99077" }
-near-sdk = "3.1.0"
-near-contract-standards = "3.1.0"
+near-sdk = "4.0.0-pre.5"
+near-contract-standards = "4.0.0-pre.5"

--- a/swt/src/lib.rs
+++ b/swt/src/lib.rs
@@ -4,10 +4,8 @@ use near_contract_standards::fungible_token::metadata::{
 use near_contract_standards::fungible_token::FungibleToken;
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::{LookupMap, LookupSet};
-use near_sdk::json_types::{ValidAccountId, U128, U64};
+use near_sdk::json_types::{U128, U64};
 use near_sdk::{env, near_bindgen, AccountId, PanicOnDefault, PromiseOrValue};
-
-near_sdk::setup_alloc!();
 
 const ICON: &str = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAoHCBUWFRgWFRYYGRgaGBgaHRwaHBwYHBoYGhwcHBgaGhocIS4lHB4rHxoaJjgnKy8xNTU1GiQ7QDs0Py40NTEBDAwMEA8QHxISHzQrJSs0NDY0PTQ0NDQxNDQ9NDU0NDQ2NjQ0NDQ0NDY0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NP/AABEIAPEA0QMBIgACEQEDEQH/xAAcAAABBQEBAQAAAAAAAAAAAAAAAQMEBQYCBwj/xAA+EAABAwIDBQYEBAUBCQAAAAABAAIRAyEEEjEFQVFhcQYigZGhsTJCwfATctHhBzNSYoLxFBUjNEOSssLD/8QAGgEAAgMBAQAAAAAAAAAAAAAAAAIBAwQFBv/EACoRAAICAQQCAgEDBQEAAAAAAAABAhEDBBIhMUFREyIyYXGRI4Gx4fAU/9oADAMBAAIRAxEAPwD2ZCEIAEIQgAQhCABCEIAYxFXK1x4AnyCyVTtDUpu73eaSCeV5gLT7V/kv/KvPdt03OaA2x3defLeubrckozSi64NenhGSdo9FwmLZUaHscC07/foVJXm3ZLa/4b2gu7jyARuDjYHlfXovSJWrT5vlj+q7KcuPZKvB0hIlWgqBCEIAEIQgBEIUbGYttNsuPQbyeASykoq2Sk26R3VrtbdxAuBcxcmAE6CvOcfiXPe5zjMkmNw3WHQAeCqMdjqtBzKlNxblcNCRO/K4aOaRNj6LAtcnKq4NP/ldd8nryFXbC2kMRQZWy5c02mYhxbEwJ0ViugmmrRlap0KhCFIAhCEACEIQAIQhAAhCEACEIQBX7ZMUXcwB6heddpc2Tu248SJ0HjC9B2+6KJHFzR6z9Fg8TUucxjd9hcjXS/qr9jdpl9f7md2XWtl4XHOSV6x2Z2iK1Ft+8wBrhzAsfEfVeRPwtRji9ozDMYIE68tQtDsDadSk7M1jhuc11gQkw5finfh9lmWG+NeUeqIVJh+0tBwGbM07wWl3q2VJbt3Dn/qDxBHuF1VmxvpowPHJeGWaExh8Q14zNIIkixm4sdE6Hg6EKxNPlC0dpEJutVa1pc4gNAkk7ghuiDjFYlrGy4wPUngFjdrbRL3E79AOA/VJtfaxeSRZt8oO4cTzKpmvtLjrfzXH1WpeR7Y9f5N+HDtVvs6ncqzb7jkAGhdf6ffNPPrHNITlQh7CC0GwseO9ZIunZoaNN/DPGl9B9Mx/w3W4w+XX8Z8ltF5n/DGuWYitRI+Jgd0NN2X1z+i9MXd07vGjm5lU2KhCFeVAhCEACEIQAIQhAAhCEAIhcPeAJJAHMwqfaG2QBlp3J+bcOnEqrJljjVyY0YSk6SIPaXaQJFNty0yeE7h11Wdo4Mudnf1A/VTmUgDO/ibrpcPLkeSbkzp44KEdqOPwW7gFAqsymNVYPdAJ4KrxNfedTuVYwqEBCAFbUcAQCQDqASAeq6pVnN+Fzm/lJbppouEKdzIomDbFZg/mujmc3vKbxWPqPEPeXAXgmB1jRRntBBBEgqrx9J5hmaWS2bd6J0J3pvkm+HJ1+5ChHwh0VTVdDZ/DGp/rPAf2+6dx+KaxtxPAJzCshqrdrMYCSRLuX1P30Sqmxhpu0WHWRyj9FY4CoHCRvAN/bzWYiTYfVaPZtLI2/wAoN08opdEp2WHYam5uPcGkQKTsxI+ISySOHeLfAHivUV5p/DWmX4mvU4My/wDe4H/5r0sLsaRVjRzdQ/uKhCFpKQQhCABCEIAEIQgBIVftPaIpiBdx0HDmeSm1agAJOgBPgNVjcXXL3Ocd58huHksmqzvHGo9suw497t9IStWLjmc4k893Qbk0hR8Zj6VETVqNYDpncGz0nVcfmT9s38JEhI0g3F1SYrajajR+G4Fh+YEEO8lN2U+GEnTMfooGriyRjHDLHRVD+8+NwUrE1NSbj6KPhm2niVAIfXRpu4HyUrC0RAcdVJQBVIUnFsAMiL7vqoyABI4SISoQAxnDGS4gATc/d1msZii9x4e/Vaeth2P+NoMcVHqbOYXNdlADZsBAJ3Sni0uwKnZeDzEOOm79VcYupkYcocbG4gRzk7/NPsYGjzSMMmZEDQfUqHK3bA0H8MqTRh3uB7zqpzcQABlHPUnxK2qwfY6s2i/Jo19v8p7vnceIW8ldrSzUsarwc3MmpsVCELSVAhCEACEIQAIQhAFZtytFIjeSAPOT6BVuzcCCMzryOGkqXj6GeoJPdbaOe8z96KUxoAgLnZI78rk+lwjTF7YUvJWbQw7crjYReTuAufReQdssPTNWnUxTn5aoeWCmMxZRY3uw1xDS973CSbBoO+I9T284va+mPmbYzoSCLrzPtfSGIoUYtXw4LHMdbOwxdp0zAtBiRYngJbT7N7flEZNyil4Mz2dqij+HUbVaXVKppGgJLssCKpOg7zgADc3jfHp7GZWht+J6nl0hZLsL2Uc14xNYQxg7oN+9/V4cQtpkL3dwH74rNrXGU/r35L9PuUeRkhLkiByEdNyn4XAmZduOnG0/oo21cQ3PHC3Of0sse2lbL7t0iawCBGiUlUmM2/To0y55gAeJO4AKjirjKL8Viq7sHgwQGZWlz35nBocQL5ZI01vuEq/DppZXx17K8mSMOzVYq5zC40kGbqOvJ62MrYSu9lHFCqGujNTcXU6ggEGHWOsHgQYO9b/s5t9mKZoG1GgZm7vzN/tPomz6SWJbu0Rjzxk68lyhCFlLgQiUIACoVmnn6BTVHxNIRI1QSh6gSIg3BkHQ8ivQtjY38ak1x10PUakcivPWCAFrux9eWPbwcD4OEf8Ar6rboZuOTb7M2pjcb9GlQhC7BgBCEIAEIQgBFzPFLKYxLxlPl5qJOlZKVkWm2SXHinVwwwBwjy6romFiLjObRBzmdN3Rcf7vpWc9jXPje0HKN3il2l2jw7HFmfM4EzlBdB6i0+KgU+0OHcfjI/M13vCyvFOMnJJl6mnFJk3FU3OytbYfMeQ3ffBOUqLWjuj9fNdMeHAOaQQdCDIPiF0qq5Hs4rPIBI3X8N6z1ahnk8N+tjxWie2QQd4IUfDYXKwtOrtY9kko2xoujyXtrs1+dhc+GOD4J0DhcZuEzErV7be3FbGacOLUzTeWDVraYLHtjflmeYbKt8QxslpAIki4mR0VeNkUQSWsDCTJyd2TxgWnwWvDrFCKjJdeinJhcm5J9nkdPCPe6GtLiTu+p3Bb/sv2cFMtrEmQ0iZIDiRBgf09dYlaBmzWSLF3AG4noNVfbL2U6o7vAtYNTp0aOd1OXVPKtsF2RDCoPdJjuwNnh7nOe2WgWmR3jEdbT5hXr9kUDcsaLRqR9deeqmUqYa0NaIAAA6CyDSBMkSVMMSjGqTFlkcnZDr7MY5oYJa0fKzKAetpKgu2DkeHMyubva/6ED3V6hM8UX2hVOSKbG7JDg4tZENIaBF3E3N+VpJ8LLL1aZBLSNCQeo1C9BWQ2/ScKjnOu35bRbhH13rPqMaS3IuwzbdMqwrvsm8isQNCwz4EQRz/UqkVt2YIFdsjUOjkY18pHiqNO6yr9y3L+DN2hIlXoDmAhCEACSEFcX4epQAuX7kqBtB4s3MON48PqpuU8vb2VXi/iPw2gaF31VOZ1EaK5G21iLAg+v7+6y/8AFLatXC4CaJIdUqNpl41a0tc5+U6Xyhs/3HSFp6A74BjXg0ehJKpv4jVGNwFTNTbUu05HQ2Qx0vII0IbJEXCrwRVWxpPwfPVTbFcxNR1uFvbVSWdo8QBGZp5lon0sq/GVGOeTTYWN/pLs8H80CyMPRa+xe1h3ZpDT/kJg9R4rSIT9k9ocThnl9Ko4EmXAnM1/HM02PCdeBC+guytb/bMMyvGUuaMzODjwdvEXHVeA7D7PvxFf8OYY0jO8EOa1sTYixJAsvo3sthxSpZGgANytGpEDWBoddR+5rnihN8oaM5RXDErYaLi0biojpmIhXGLbmhwBnXvQ2ANbGIjjc3VZizMGR0zN0WDNh2M0QyX2cYbZNOoHF2YGdQdJA+oPmnj2epRYunrrbfbjeyk7MPdM6br+BU8BEcUHFNoiU5J8Mq8FsRtNzXZnFw4xE9IsrQCNEqFbGMYqoiNuXYIQhMQCEIQALLdpabg8OM5CBF7TvgT0WpWX7SUH5w8juwGgyD6QCPXqs+o/AsxfmUifwVc03tePldPUbx4gkeKaDV1C52/a7Rt22uT0im8OaHC4IBHQ3C7VT2aq5qAB+Ulv1HoQrdeixz3wUvaOVJVJoEJUJxQSSgohSByfP2VXiW94yd/QdIVqSqrHA5jzA++Sozr6jw7GBVykHSD99PUrO9rqzi+HfA5stmDDYE/FzlaJrI013lV+38Kx1E5rQZBiZJtB5FUQnt4LHGzxLb/ZRweXUACCSSyzY/LJuNSdI9mdl9k3k5q/daC2zS1xcCbyQYDY3idRCvsZ2rZTcQ6hUifilpDoPdIvA0BjVOYftDhK4LTDXXOWoAAbgmHXbeBabrVcqKqRebFwLKYYWM+DK3LkPddlJLiTcgggZr716PgHsbTaWhrQZeXEgNdJiS6LuI0B4cl55hg2XklzmvDYIdLRlkENA9brXbL2icgz0RJAa6wGZrfhDh82tjG5J8kY8yZO1vovnVaTZaRlygWgEAO3C19NAs85wJPeEyeXlyT2KxGcCBlGpEkgGI7s/CIiw6pkDj63Cw6jMptJdI0Y4bey2wzSWNIMQbidb85Uj8WDGXxF7cVW0e7GW3Q2UulXOWJiOWoTRnwLJE1pXSh0sUJvafEdeWgTlTFAAEXn7unUlVi7WSExUxTRzPJQqtYuMzHAcE2klk9DKPslnGngFyMY7lr9hRS4JGkpN79jbUSnY119PJUW2Md+JlbuaTfjIEH3Vo8iLrNLPnySrbfZdhgrsEISSshoNN2Rq2e3mHDxEH2C0qxXZ+qG1M3gfyn97+C2y7mhnuxJejm6iNTsEJULaUAhCEAcwoGObcHiI+/NWBTOKZLTyv5JMi3RaGi6ZWAKNjqGdjm8vZSSVHe+BefvT/Rc6T4L0eZbV7OvY85ILSJgm5M6Dl1Wbxex2zlfSAceUE3j5dbr1+tSa/4h+3RRhs1kzc8v3RDVNLkZ40zyHC4F9Hv0Kr6ea25zT4EQdN61uze2dVkNxFIOA1fSuY0uwmedpW0dg2FmUsbl0iN2igP7N4cmcg1BjTTpCaWohP8AJEKDj0yixXbku/5XD1arT8xa4MneBMIwm3do1hDcM2nNsznGwO/KBJjhI6rX08KxujR7+Up6FT8kEvrH+RtsvLKjYeExDHOfXrF8gANyhjW33AEnzK0LDIUYBSGNgJVJydktJHSELgvCZuiBXVAE0ahXCcZTlV7m+hqSOWsJT7WwkY2EPeACToBKaKohuyq2lWcHubuIbHSZPqFAUzadYOfA3WJ4n9rqESseR3JmmCqKAlM06uZxjQDXmf8ARRa1cm026QptCmGhJVFhNwNWHRx+wtxs2pmptPKPKyweGfldMSYsOZ+ythsJ3dd1HqF0NBOpV7MeqjxZboQhdkwghCEACEIQBmtoNNJ5v3XCR53Cj1Hyd/ints1Mzz/bYdRqqtuKh2R28SDxjUHmuHmklNpdWb4Rbin5JaEiVIAiVCEAEJ1lPihlQQnQnikK2xGtASoJTNV+5O2kgSs6dUTTnSkQqnJslKgT1Ib0jafFOTuTRjXLIbFVbtasRDBoRJ87BWD3ECwk9YVbjDlOd+Uv+VuoaOJ4oyv60NjX2srVDxdb5RHNdY6s7jrqZuVBWRLya0ScIxpN9dwU9Q8FTOsKa1pJAGpSy7BknA0pdm3D3Wn2C67hyafKZ9wqXDU8rQPHxKtNjfzP8T9LHwnyW7SfWaMed7kzQoSJV2zCCEIQAiaxE5XZdcpjrFk6mcTUytceAKWX4sldmVKr8VQztLd+7qrBNVmb1wJo6MHTKzCY11MhlTTc6d272Vu1wOigYmgHtynz4HiqxzKtIgNJI3QJHMRuKRSoscVI0iFRN22Yuy/W3snxttsDumd+ifcit45FslDiqaptwSMrJG+THkuTtzgz1U7kHxsuiULPu2086BoHiVxRxVd5hrjbfYD2uo3In42aCpUa0S4gD704pMNVcZJAHAawOZ4qDQwwBzOJc7eTBI6GLBWlJnK3kiLbfBEkoo7BzarpjblJnaNF3KvVFLFUHF4QvNrDUnid3MnnuU5QdoYvKMjfiI8gfqlybdvI0LvgoKtETmO7XmoLGFxtvUusS85G+J+iscBs3Ld32f0WWKbNbkorkaoskgD0VrTw7W6BFHDtboL8U6njGuyiU76BS+y1SXVAdRlPuCq3GVIYeJsu+zFQivE/E1084v5/ur8MtuaP/diTjeNs2iEIXcMAIQhACKDtafwzHj04ecKcq3bVWGRvcfQXP0VWZpY3foaH5IokhSoXFNpHfTjom1LKYqU46KuUaLYyvhlBtKjlfPH1/f76Qlpa1IPaWnQ/cqvxWzu4C2JbrukfqlLUyqXbGEkAakwuQFZYDDd8zBGUE7xJ0H1QS2JhtnE/GCOcj2+9FaUaQaA1oTrGSn2sAUqNlcpUctpDenEIViVFLbYIlCFJB018KK7CgkkkyZv1/ZSEAKGr4ZKddDdLDNEBrQI0UltPiu2sAXSsjBIRybOPwwmXiCpKYqm6mSVBFlftE2HX/Rd9nf57P8v/ABKa2i24PGVzsp+WtTP97R4EwfdZ4OssW/aL6vG1+jPQEIQvQ2csVCEJgEWe2riMzoGjbeO8/fBaFZrH4NzHTq0mx+h5rHrN2zjryW4a3ckVCELmGoEhCVCAIz2QmyJsVJrCyjqqSpl0XaKChhi5+QHQmTyCvg0DRDWAEkC51PFPUmzqFCVkykOtaAukIVxSCEIQQCF2KZToYOCZRbIbGWMJTrGQu0J1FIhuwQhCYgCoOJqgAmeMJ/F1Q1t/vgqSrVLtVnzTrgtxxvk4c8nVOYMS9g4vYPNwTStdgbPNSoHaNY4Eni4GQ0fVU4oynkSRbOSjFtmzQu4QvQ7GcqxUIQrSBFxUphwIIkHcnEijsDPY/Z5Z3m3b6jry5qCteqnG7KnvMseG7w4Ln59K19ofwaIZfEimQlc0gwQQRuKRYS85dpZRVMXApiZSyjYylQyxklSGiEAJQiMaCUrBACXKnWU4TxjYjYjKfFOBoSoVqSQtghCFIAhCEACbr1msEuP7pxU+PqF57t2jfG/f1STltQ0Y7mc4vHZxlAgTPNQ10WHNlg5piNTPKNVf7L7PEw6tYbmjU/mI06D0WeGPJmlSX+i6U4Y48ldsrZTqzp0YDc/RvE+y2uGoNY0NaIA0C6p0w0ANAAFgBYALsLtafTRwrjl+zBlyub/QVKkQtJUKhCEACEIQAIQhAEfE4ZrxDh0O8dCqfE7Kc27e8PXy3q/QVTkwQn2uR4zcejIOEWNihamrh2u+IA+/nqodTZY+VxHI3WKejkvxdlyzJ9lIGHgu6TIU9+z3jcD0P6wmHUXDVrh4FVfDKL5TG3pjcJUFCCQQhCABCF01hOgJ6CUAcoT7cI86NPjb3Uinsx29wHS6sWKb6QrlFeSAU9htnk6NDRxiPIb1bUcG1twJPE3P7eCkq+Gl8yK5ZfRGw+Da24EnidVJQlWuMVFUiptvsEIQmIBCEIAEIQgAQhCABCEIARCEIAVIlQgBEIQoZI1V0VXitClQseYtgVrdVa0NAhCz4uyyZYU04hC3R6M7FSoQrkKCEIUgIlQhAAhCEACEIQB//9k=";
 const DECIMALS: f64 = 1000000000000000000.;
@@ -30,7 +28,7 @@ impl Contract {
     pub fn new(oracles_vec: Vec<AccountId>) -> Self {
         let mut oracles_tree = LookupSet::new(b"s");
         for oracle in oracles_vec.iter() {
-            env::log(oracle.as_bytes());
+            env::log_str(oracle.as_str());
             oracles_tree.insert(oracle);
         }
         Self {
@@ -45,21 +43,20 @@ impl Contract {
         self.steps_from_tge
     }
 
-    pub fn record_batch(&mut self, steps_batch: Vec<(ValidAccountId, u32)>) {
+    pub fn record_batch(&mut self, steps_batch: Vec<(AccountId, u32)>) {
         assert!(self.oracles.contains(&env::predecessor_account_id()));
         for (account_id, steps) in steps_batch.into_iter() {
             self.record(&account_id, steps);
         }
     }
 
-    fn record(&mut self, account_id: &ValidAccountId, steps: u32) -> U128 {
-        if !self.token.accounts.contains_key(account_id.as_ref()) {
-            self.token.internal_register_account(account_id.as_ref());
+    fn record(&mut self, account_id: &AccountId, steps: u32) -> U128 {
+        if !self.token.accounts.contains_key(account_id) {
+            self.token.internal_register_account(account_id);
         }
         let capped_steps = self.get_capped_steps(account_id, steps);
         let swt = self.formula(self.steps_from_tge, capped_steps);
-        self.token
-            .internal_deposit(account_id.as_ref(), swt.0 as u128);
+        self.token.internal_deposit(account_id, swt.0 as u128);
         self.steps_from_tge.0 += capped_steps as u64;
         swt
     }
@@ -71,8 +68,8 @@ impl Contract {
         U128(swt as u128)
     }
 
-    fn get_capped_steps(&mut self, account_id: &ValidAccountId, steps_to_convert: u32) -> u32 {
-        let (mut sum, mut ts) = self.daily_limits.get(account_id.as_ref()).unwrap_or((0, 0));
+    fn get_capped_steps(&mut self, account_id: &AccountId, steps_to_convert: u32) -> u32 {
+        let (mut sum, mut ts) = self.daily_limits.get(account_id).unwrap_or((0, 0));
         let current_ts: u64 = env::block_timestamp();
         //let current_ts:u64 = env::block_timestamp() + 10; // :todo: for debug tests
         let mut remaining_steps = 2 * DAILY_STEP_CONVERSION_LIMIT;
@@ -85,7 +82,7 @@ impl Contract {
         remaining_steps = i32::max(0, remaining_steps as i32 - sum as i32) as u32;
         let capped_steps: u32 = u32::min(remaining_steps, steps_to_convert);
         self.daily_limits
-            .insert(account_id.as_ref(), &(sum + capped_steps, ts));
+            .insert(account_id, &(sum + capped_steps, ts));
         // println!("time = {}, remaining_steps = {}, steps_to_convert = {}, sum = {}", current_ts, remaining_steps, steps_to_convert, sum);
         capped_steps
     }
@@ -114,9 +111,7 @@ impl FungibleTokenMetadataProvider for Contract {
 mod tests {
     use super::*;
     use near_sdk::test_utils::VMContextBuilder;
-    use near_sdk::MockedBlockchain;
-    use near_sdk::{testing_env, VMContext};
-    use std::convert::TryInto;
+    use near_sdk::VMContext;
 
     fn get_context(is_view: bool) -> VMContext {
         VMContextBuilder::new().is_view(is_view).build()
@@ -181,7 +176,7 @@ mod tests {
         testing_env!(context);
         println!("test_formula2: =====================================");
         {
-            let alice:ValidAccountId = "alice.testnet".try_into().unwrap();
+            let alice:AccountId = "alice.testnet".try_into().unwrap();
             let steps_from_tge = vec!(0, 2_000, 10_000, 100_000, 1_000_000, 1_500_500, 2_000_000, 2_500_000, 10_000_000, 50_000_000, 1_000_000_000, 1_000_000_000_000_000_000, 1_000_000_000_000_000_000_000u128);
             for tge in steps_from_tge {
                 let oracles = vec!["intmainreturn0.testnet".to_string()];
@@ -235,12 +230,10 @@ mod tests {
 
     #[test]
     fn test_daily_cap1() {
-        let context = get_context(false);
-        testing_env!(context);
-        let oracles = vec!["intmainreturn0.testnet".to_string()];
+        let oracles = vec!["intmainreturn0.testnet".parse().unwrap()];
         let mut contract = Contract::new(oracles);
         assert_eq!(U64(0), contract.get_steps_from_tge());
-        let alice: ValidAccountId = "alice.testnet".try_into().unwrap();
+        let alice: AccountId = "alice.testnet".parse().unwrap();
 
         let mut swt: f64 = contract.record(&alice, 10_000).0 as f64 / DECIMALS;
         assert_eq!(10_000, contract.get_steps_from_tge().0);

--- a/swt/src/lib.rs
+++ b/swt/src/lib.rs
@@ -3,17 +3,16 @@ use near_contract_standards::fungible_token::metadata::{
 };
 use near_contract_standards::fungible_token::FungibleToken;
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::json_types::{ValidAccountId, U64, U128};
-use near_sdk::{near_bindgen, AccountId, PanicOnDefault, PromiseOrValue, env};
-use near_sdk::collections::{LookupSet, LookupMap};
+use near_sdk::collections::{LookupMap, LookupSet};
+use near_sdk::json_types::{ValidAccountId, U128, U64};
+use near_sdk::{env, near_bindgen, AccountId, PanicOnDefault, PromiseOrValue};
 
 near_sdk::setup_alloc!();
 
-
-const ICON: &'static str = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAoHCBUWFRgWFRYYGRgaGBgaHRwaHBwYHBoYGhwcHBgaGhocIS4lHB4rHxoaJjgnKy8xNTU1GiQ7QDs0Py40NTEBDAwMEA8QHxISHzQrJSs0NDY0PTQ0NDQxNDQ9NDU0NDQ2NjQ0NDQ0NDY0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NP/AABEIAPEA0QMBIgACEQEDEQH/xAAcAAABBQEBAQAAAAAAAAAAAAAAAQMEBQYCBwj/xAA+EAABAwIDBQYEBAUBCQAAAAABAAIRAyEEEjEFQVFhcQYigZGhsTJCwfATctHhBzNSYoLxFBUjNEOSssLD/8QAGgEAAgMBAQAAAAAAAAAAAAAAAAIBAwQFBv/EACoRAAICAQQCAgEDBQEAAAAAAAABAhEDBBIhMUFREyIyYXGRI4Gx4fAU/9oADAMBAAIRAxEAPwD2ZCEIAEIQgAQhCABCEIAYxFXK1x4AnyCyVTtDUpu73eaSCeV5gLT7V/kv/KvPdt03OaA2x3defLeubrckozSi64NenhGSdo9FwmLZUaHscC07/foVJXm3ZLa/4b2gu7jyARuDjYHlfXovSJWrT5vlj+q7KcuPZKvB0hIlWgqBCEIAEIQgBEIUbGYttNsuPQbyeASykoq2Sk26R3VrtbdxAuBcxcmAE6CvOcfiXPe5zjMkmNw3WHQAeCqMdjqtBzKlNxblcNCRO/K4aOaRNj6LAtcnKq4NP/ldd8nryFXbC2kMRQZWy5c02mYhxbEwJ0ViugmmrRlap0KhCFIAhCEACEIQAIQhAAhCEACEIQBX7ZMUXcwB6heddpc2Tu248SJ0HjC9B2+6KJHFzR6z9Fg8TUucxjd9hcjXS/qr9jdpl9f7md2XWtl4XHOSV6x2Z2iK1Ft+8wBrhzAsfEfVeRPwtRji9ozDMYIE68tQtDsDadSk7M1jhuc11gQkw5finfh9lmWG+NeUeqIVJh+0tBwGbM07wWl3q2VJbt3Dn/qDxBHuF1VmxvpowPHJeGWaExh8Q14zNIIkixm4sdE6Hg6EKxNPlC0dpEJutVa1pc4gNAkk7ghuiDjFYlrGy4wPUngFjdrbRL3E79AOA/VJtfaxeSRZt8oO4cTzKpmvtLjrfzXH1WpeR7Y9f5N+HDtVvs6ncqzb7jkAGhdf6ffNPPrHNITlQh7CC0GwseO9ZIunZoaNN/DPGl9B9Mx/w3W4w+XX8Z8ltF5n/DGuWYitRI+Jgd0NN2X1z+i9MXd07vGjm5lU2KhCFeVAhCEACEIQAIQhAAhCEAIhcPeAJJAHMwqfaG2QBlp3J+bcOnEqrJljjVyY0YSk6SIPaXaQJFNty0yeE7h11Wdo4Mudnf1A/VTmUgDO/ibrpcPLkeSbkzp44KEdqOPwW7gFAqsymNVYPdAJ4KrxNfedTuVYwqEBCAFbUcAQCQDqASAeq6pVnN+Fzm/lJbppouEKdzIomDbFZg/mujmc3vKbxWPqPEPeXAXgmB1jRRntBBBEgqrx9J5hmaWS2bd6J0J3pvkm+HJ1+5ChHwh0VTVdDZ/DGp/rPAf2+6dx+KaxtxPAJzCshqrdrMYCSRLuX1P30Sqmxhpu0WHWRyj9FY4CoHCRvAN/bzWYiTYfVaPZtLI2/wAoN08opdEp2WHYam5uPcGkQKTsxI+ISySOHeLfAHivUV5p/DWmX4mvU4My/wDe4H/5r0sLsaRVjRzdQ/uKhCFpKQQhCABCEIAEIQgBIVftPaIpiBdx0HDmeSm1agAJOgBPgNVjcXXL3Ocd58huHksmqzvHGo9suw497t9IStWLjmc4k893Qbk0hR8Zj6VETVqNYDpncGz0nVcfmT9s38JEhI0g3F1SYrajajR+G4Fh+YEEO8lN2U+GEnTMfooGriyRjHDLHRVD+8+NwUrE1NSbj6KPhm2niVAIfXRpu4HyUrC0RAcdVJQBVIUnFsAMiL7vqoyABI4SISoQAxnDGS4gATc/d1msZii9x4e/Vaeth2P+NoMcVHqbOYXNdlADZsBAJ3Sni0uwKnZeDzEOOm79VcYupkYcocbG4gRzk7/NPsYGjzSMMmZEDQfUqHK3bA0H8MqTRh3uB7zqpzcQABlHPUnxK2qwfY6s2i/Jo19v8p7vnceIW8ldrSzUsarwc3MmpsVCELSVAhCEACEIQAIQhAFZtytFIjeSAPOT6BVuzcCCMzryOGkqXj6GeoJPdbaOe8z96KUxoAgLnZI78rk+lwjTF7YUvJWbQw7crjYReTuAufReQdssPTNWnUxTn5aoeWCmMxZRY3uw1xDS973CSbBoO+I9T284va+mPmbYzoSCLrzPtfSGIoUYtXw4LHMdbOwxdp0zAtBiRYngJbT7N7flEZNyil4Mz2dqij+HUbVaXVKppGgJLssCKpOg7zgADc3jfHp7GZWht+J6nl0hZLsL2Uc14xNYQxg7oN+9/V4cQtpkL3dwH74rNrXGU/r35L9PuUeRkhLkiByEdNyn4XAmZduOnG0/oo21cQ3PHC3Of0sse2lbL7t0iawCBGiUlUmM2/To0y55gAeJO4AKjirjKL8Viq7sHgwQGZWlz35nBocQL5ZI01vuEq/DppZXx17K8mSMOzVYq5zC40kGbqOvJ62MrYSu9lHFCqGujNTcXU6ggEGHWOsHgQYO9b/s5t9mKZoG1GgZm7vzN/tPomz6SWJbu0Rjzxk68lyhCFlLgQiUIACoVmnn6BTVHxNIRI1QSh6gSIg3BkHQ8ivQtjY38ak1x10PUakcivPWCAFrux9eWPbwcD4OEf8Ar6rboZuOTb7M2pjcb9GlQhC7BgBCEIAEIQgBFzPFLKYxLxlPl5qJOlZKVkWm2SXHinVwwwBwjy6romFiLjObRBzmdN3Rcf7vpWc9jXPje0HKN3il2l2jw7HFmfM4EzlBdB6i0+KgU+0OHcfjI/M13vCyvFOMnJJl6mnFJk3FU3OytbYfMeQ3ffBOUqLWjuj9fNdMeHAOaQQdCDIPiF0qq5Hs4rPIBI3X8N6z1ahnk8N+tjxWie2QQd4IUfDYXKwtOrtY9kko2xoujyXtrs1+dhc+GOD4J0DhcZuEzErV7be3FbGacOLUzTeWDVraYLHtjflmeYbKt8QxslpAIki4mR0VeNkUQSWsDCTJyd2TxgWnwWvDrFCKjJdeinJhcm5J9nkdPCPe6GtLiTu+p3Bb/sv2cFMtrEmQ0iZIDiRBgf09dYlaBmzWSLF3AG4noNVfbL2U6o7vAtYNTp0aOd1OXVPKtsF2RDCoPdJjuwNnh7nOe2WgWmR3jEdbT5hXr9kUDcsaLRqR9deeqmUqYa0NaIAAA6CyDSBMkSVMMSjGqTFlkcnZDr7MY5oYJa0fKzKAetpKgu2DkeHMyubva/6ED3V6hM8UX2hVOSKbG7JDg4tZENIaBF3E3N+VpJ8LLL1aZBLSNCQeo1C9BWQ2/ScKjnOu35bRbhH13rPqMaS3IuwzbdMqwrvsm8isQNCwz4EQRz/UqkVt2YIFdsjUOjkY18pHiqNO6yr9y3L+DN2hIlXoDmAhCEACSEFcX4epQAuX7kqBtB4s3MON48PqpuU8vb2VXi/iPw2gaF31VOZ1EaK5G21iLAg+v7+6y/8AFLatXC4CaJIdUqNpl41a0tc5+U6Xyhs/3HSFp6A74BjXg0ehJKpv4jVGNwFTNTbUu05HQ2Qx0vII0IbJEXCrwRVWxpPwfPVTbFcxNR1uFvbVSWdo8QBGZp5lon0sq/GVGOeTTYWN/pLs8H80CyMPRa+xe1h3ZpDT/kJg9R4rSIT9k9ocThnl9Ko4EmXAnM1/HM02PCdeBC+guytb/bMMyvGUuaMzODjwdvEXHVeA7D7PvxFf8OYY0jO8EOa1sTYixJAsvo3sthxSpZGgANytGpEDWBoddR+5rnihN8oaM5RXDErYaLi0biojpmIhXGLbmhwBnXvQ2ANbGIjjc3VZizMGR0zN0WDNh2M0QyX2cYbZNOoHF2YGdQdJA+oPmnj2epRYunrrbfbjeyk7MPdM6br+BU8BEcUHFNoiU5J8Mq8FsRtNzXZnFw4xE9IsrQCNEqFbGMYqoiNuXYIQhMQCEIQALLdpabg8OM5CBF7TvgT0WpWX7SUH5w8juwGgyD6QCPXqs+o/AsxfmUifwVc03tePldPUbx4gkeKaDV1C52/a7Rt22uT0im8OaHC4IBHQ3C7VT2aq5qAB+Ulv1HoQrdeixz3wUvaOVJVJoEJUJxQSSgohSByfP2VXiW94yd/QdIVqSqrHA5jzA++Sozr6jw7GBVykHSD99PUrO9rqzi+HfA5stmDDYE/FzlaJrI013lV+38Kx1E5rQZBiZJtB5FUQnt4LHGzxLb/ZRweXUACCSSyzY/LJuNSdI9mdl9k3k5q/daC2zS1xcCbyQYDY3idRCvsZ2rZTcQ6hUifilpDoPdIvA0BjVOYftDhK4LTDXXOWoAAbgmHXbeBabrVcqKqRebFwLKYYWM+DK3LkPddlJLiTcgggZr716PgHsbTaWhrQZeXEgNdJiS6LuI0B4cl55hg2XklzmvDYIdLRlkENA9brXbL2icgz0RJAa6wGZrfhDh82tjG5J8kY8yZO1vovnVaTZaRlygWgEAO3C19NAs85wJPeEyeXlyT2KxGcCBlGpEkgGI7s/CIiw6pkDj63Cw6jMptJdI0Y4bey2wzSWNIMQbidb85Uj8WDGXxF7cVW0e7GW3Q2UulXOWJiOWoTRnwLJE1pXSh0sUJvafEdeWgTlTFAAEXn7unUlVi7WSExUxTRzPJQqtYuMzHAcE2klk9DKPslnGngFyMY7lr9hRS4JGkpN79jbUSnY119PJUW2Md+JlbuaTfjIEH3Vo8iLrNLPnySrbfZdhgrsEISSshoNN2Rq2e3mHDxEH2C0qxXZ+qG1M3gfyn97+C2y7mhnuxJejm6iNTsEJULaUAhCEAcwoGObcHiI+/NWBTOKZLTyv5JMi3RaGi6ZWAKNjqGdjm8vZSSVHe+BefvT/Rc6T4L0eZbV7OvY85ILSJgm5M6Dl1Wbxex2zlfSAceUE3j5dbr1+tSa/4h+3RRhs1kzc8v3RDVNLkZ40zyHC4F9Hv0Kr6ea25zT4EQdN61uze2dVkNxFIOA1fSuY0uwmedpW0dg2FmUsbl0iN2igP7N4cmcg1BjTTpCaWohP8AJEKDj0yixXbku/5XD1arT8xa4MneBMIwm3do1hDcM2nNsznGwO/KBJjhI6rX08KxujR7+Up6FT8kEvrH+RtsvLKjYeExDHOfXrF8gANyhjW33AEnzK0LDIUYBSGNgJVJydktJHSELgvCZuiBXVAE0ahXCcZTlV7m+hqSOWsJT7WwkY2EPeACToBKaKohuyq2lWcHubuIbHSZPqFAUzadYOfA3WJ4n9rqESseR3JmmCqKAlM06uZxjQDXmf8ARRa1cm026QptCmGhJVFhNwNWHRx+wtxs2pmptPKPKyweGfldMSYsOZ+ythsJ3dd1HqF0NBOpV7MeqjxZboQhdkwghCEACEIQBmtoNNJ5v3XCR53Cj1Hyd/ints1Mzz/bYdRqqtuKh2R28SDxjUHmuHmklNpdWb4Rbin5JaEiVIAiVCEAEJ1lPihlQQnQnikK2xGtASoJTNV+5O2kgSs6dUTTnSkQqnJslKgT1Ib0jafFOTuTRjXLIbFVbtasRDBoRJ87BWD3ECwk9YVbjDlOd+Uv+VuoaOJ4oyv60NjX2srVDxdb5RHNdY6s7jrqZuVBWRLya0ScIxpN9dwU9Q8FTOsKa1pJAGpSy7BknA0pdm3D3Wn2C67hyafKZ9wqXDU8rQPHxKtNjfzP8T9LHwnyW7SfWaMed7kzQoSJV2zCCEIQAiaxE5XZdcpjrFk6mcTUytceAKWX4sldmVKr8VQztLd+7qrBNVmb1wJo6MHTKzCY11MhlTTc6d272Vu1wOigYmgHtynz4HiqxzKtIgNJI3QJHMRuKRSoscVI0iFRN22Yuy/W3snxttsDumd+ifcit45FslDiqaptwSMrJG+THkuTtzgz1U7kHxsuiULPu2086BoHiVxRxVd5hrjbfYD2uo3In42aCpUa0S4gD704pMNVcZJAHAawOZ4qDQwwBzOJc7eTBI6GLBWlJnK3kiLbfBEkoo7BzarpjblJnaNF3KvVFLFUHF4QvNrDUnid3MnnuU5QdoYvKMjfiI8gfqlybdvI0LvgoKtETmO7XmoLGFxtvUusS85G+J+iscBs3Ld32f0WWKbNbkorkaoskgD0VrTw7W6BFHDtboL8U6njGuyiU76BS+y1SXVAdRlPuCq3GVIYeJsu+zFQivE/E1084v5/ur8MtuaP/diTjeNs2iEIXcMAIQhACKDtafwzHj04ecKcq3bVWGRvcfQXP0VWZpY3foaH5IokhSoXFNpHfTjom1LKYqU46KuUaLYyvhlBtKjlfPH1/f76Qlpa1IPaWnQ/cqvxWzu4C2JbrukfqlLUyqXbGEkAakwuQFZYDDd8zBGUE7xJ0H1QS2JhtnE/GCOcj2+9FaUaQaA1oTrGSn2sAUqNlcpUctpDenEIViVFLbYIlCFJB018KK7CgkkkyZv1/ZSEAKGr4ZKddDdLDNEBrQI0UltPiu2sAXSsjBIRybOPwwmXiCpKYqm6mSVBFlftE2HX/Rd9nf57P8v/ABKa2i24PGVzsp+WtTP97R4EwfdZ4OssW/aL6vG1+jPQEIQvQ2csVCEJgEWe2riMzoGjbeO8/fBaFZrH4NzHTq0mx+h5rHrN2zjryW4a3ckVCELmGoEhCVCAIz2QmyJsVJrCyjqqSpl0XaKChhi5+QHQmTyCvg0DRDWAEkC51PFPUmzqFCVkykOtaAukIVxSCEIQQCF2KZToYOCZRbIbGWMJTrGQu0J1FIhuwQhCYgCoOJqgAmeMJ/F1Q1t/vgqSrVLtVnzTrgtxxvk4c8nVOYMS9g4vYPNwTStdgbPNSoHaNY4Eni4GQ0fVU4oynkSRbOSjFtmzQu4QvQ7GcqxUIQrSBFxUphwIIkHcnEijsDPY/Z5Z3m3b6jry5qCteqnG7KnvMseG7w4Ln59K19ofwaIZfEimQlc0gwQQRuKRYS85dpZRVMXApiZSyjYylQyxklSGiEAJQiMaCUrBACXKnWU4TxjYjYjKfFOBoSoVqSQtghCFIAhCEACbr1msEuP7pxU+PqF57t2jfG/f1STltQ0Y7mc4vHZxlAgTPNQ10WHNlg5piNTPKNVf7L7PEw6tYbmjU/mI06D0WeGPJmlSX+i6U4Y48ldsrZTqzp0YDc/RvE+y2uGoNY0NaIA0C6p0w0ANAAFgBYALsLtafTRwrjl+zBlyub/QVKkQtJUKhCEACEIQAIQhAEfE4ZrxDh0O8dCqfE7Kc27e8PXy3q/QVTkwQn2uR4zcejIOEWNihamrh2u+IA+/nqodTZY+VxHI3WKejkvxdlyzJ9lIGHgu6TIU9+z3jcD0P6wmHUXDVrh4FVfDKL5TG3pjcJUFCCQQhCABCF01hOgJ6CUAcoT7cI86NPjb3Uinsx29wHS6sWKb6QrlFeSAU9htnk6NDRxiPIb1bUcG1twJPE3P7eCkq+Gl8yK5ZfRGw+Da24EnidVJQlWuMVFUiptvsEIQmIBCEIAEIQgAQhCABCEIARCEIAVIlQgBEIQoZI1V0VXitClQseYtgVrdVa0NAhCz4uyyZYU04hC3R6M7FSoQrkKCEIUgIlQhAAhCEACEIQB//9k=";
+const ICON: &str = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAoHCBUWFRgWFRYYGRgaGBgaHRwaHBwYHBoYGhwcHBgaGhocIS4lHB4rHxoaJjgnKy8xNTU1GiQ7QDs0Py40NTEBDAwMEA8QHxISHzQrJSs0NDY0PTQ0NDQxNDQ9NDU0NDQ2NjQ0NDQ0NDY0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NP/AABEIAPEA0QMBIgACEQEDEQH/xAAcAAABBQEBAQAAAAAAAAAAAAAAAQMEBQYCBwj/xAA+EAABAwIDBQYEBAUBCQAAAAABAAIRAyEEEjEFQVFhcQYigZGhsTJCwfATctHhBzNSYoLxFBUjNEOSssLD/8QAGgEAAgMBAQAAAAAAAAAAAAAAAAIBAwQFBv/EACoRAAICAQQCAgEDBQEAAAAAAAABAhEDBBIhMUFREyIyYXGRI4Gx4fAU/9oADAMBAAIRAxEAPwD2ZCEIAEIQgAQhCABCEIAYxFXK1x4AnyCyVTtDUpu73eaSCeV5gLT7V/kv/KvPdt03OaA2x3defLeubrckozSi64NenhGSdo9FwmLZUaHscC07/foVJXm3ZLa/4b2gu7jyARuDjYHlfXovSJWrT5vlj+q7KcuPZKvB0hIlWgqBCEIAEIQgBEIUbGYttNsuPQbyeASykoq2Sk26R3VrtbdxAuBcxcmAE6CvOcfiXPe5zjMkmNw3WHQAeCqMdjqtBzKlNxblcNCRO/K4aOaRNj6LAtcnKq4NP/ldd8nryFXbC2kMRQZWy5c02mYhxbEwJ0ViugmmrRlap0KhCFIAhCEACEIQAIQhAAhCEACEIQBX7ZMUXcwB6heddpc2Tu248SJ0HjC9B2+6KJHFzR6z9Fg8TUucxjd9hcjXS/qr9jdpl9f7md2XWtl4XHOSV6x2Z2iK1Ft+8wBrhzAsfEfVeRPwtRji9ozDMYIE68tQtDsDadSk7M1jhuc11gQkw5finfh9lmWG+NeUeqIVJh+0tBwGbM07wWl3q2VJbt3Dn/qDxBHuF1VmxvpowPHJeGWaExh8Q14zNIIkixm4sdE6Hg6EKxNPlC0dpEJutVa1pc4gNAkk7ghuiDjFYlrGy4wPUngFjdrbRL3E79AOA/VJtfaxeSRZt8oO4cTzKpmvtLjrfzXH1WpeR7Y9f5N+HDtVvs6ncqzb7jkAGhdf6ffNPPrHNITlQh7CC0GwseO9ZIunZoaNN/DPGl9B9Mx/w3W4w+XX8Z8ltF5n/DGuWYitRI+Jgd0NN2X1z+i9MXd07vGjm5lU2KhCFeVAhCEACEIQAIQhAAhCEAIhcPeAJJAHMwqfaG2QBlp3J+bcOnEqrJljjVyY0YSk6SIPaXaQJFNty0yeE7h11Wdo4Mudnf1A/VTmUgDO/ibrpcPLkeSbkzp44KEdqOPwW7gFAqsymNVYPdAJ4KrxNfedTuVYwqEBCAFbUcAQCQDqASAeq6pVnN+Fzm/lJbppouEKdzIomDbFZg/mujmc3vKbxWPqPEPeXAXgmB1jRRntBBBEgqrx9J5hmaWS2bd6J0J3pvkm+HJ1+5ChHwh0VTVdDZ/DGp/rPAf2+6dx+KaxtxPAJzCshqrdrMYCSRLuX1P30Sqmxhpu0WHWRyj9FY4CoHCRvAN/bzWYiTYfVaPZtLI2/wAoN08opdEp2WHYam5uPcGkQKTsxI+ISySOHeLfAHivUV5p/DWmX4mvU4My/wDe4H/5r0sLsaRVjRzdQ/uKhCFpKQQhCABCEIAEIQgBIVftPaIpiBdx0HDmeSm1agAJOgBPgNVjcXXL3Ocd58huHksmqzvHGo9suw497t9IStWLjmc4k893Qbk0hR8Zj6VETVqNYDpncGz0nVcfmT9s38JEhI0g3F1SYrajajR+G4Fh+YEEO8lN2U+GEnTMfooGriyRjHDLHRVD+8+NwUrE1NSbj6KPhm2niVAIfXRpu4HyUrC0RAcdVJQBVIUnFsAMiL7vqoyABI4SISoQAxnDGS4gATc/d1msZii9x4e/Vaeth2P+NoMcVHqbOYXNdlADZsBAJ3Sni0uwKnZeDzEOOm79VcYupkYcocbG4gRzk7/NPsYGjzSMMmZEDQfUqHK3bA0H8MqTRh3uB7zqpzcQABlHPUnxK2qwfY6s2i/Jo19v8p7vnceIW8ldrSzUsarwc3MmpsVCELSVAhCEACEIQAIQhAFZtytFIjeSAPOT6BVuzcCCMzryOGkqXj6GeoJPdbaOe8z96KUxoAgLnZI78rk+lwjTF7YUvJWbQw7crjYReTuAufReQdssPTNWnUxTn5aoeWCmMxZRY3uw1xDS973CSbBoO+I9T284va+mPmbYzoSCLrzPtfSGIoUYtXw4LHMdbOwxdp0zAtBiRYngJbT7N7flEZNyil4Mz2dqij+HUbVaXVKppGgJLssCKpOg7zgADc3jfHp7GZWht+J6nl0hZLsL2Uc14xNYQxg7oN+9/V4cQtpkL3dwH74rNrXGU/r35L9PuUeRkhLkiByEdNyn4XAmZduOnG0/oo21cQ3PHC3Of0sse2lbL7t0iawCBGiUlUmM2/To0y55gAeJO4AKjirjKL8Viq7sHgwQGZWlz35nBocQL5ZI01vuEq/DppZXx17K8mSMOzVYq5zC40kGbqOvJ62MrYSu9lHFCqGujNTcXU6ggEGHWOsHgQYO9b/s5t9mKZoG1GgZm7vzN/tPomz6SWJbu0Rjzxk68lyhCFlLgQiUIACoVmnn6BTVHxNIRI1QSh6gSIg3BkHQ8ivQtjY38ak1x10PUakcivPWCAFrux9eWPbwcD4OEf8Ar6rboZuOTb7M2pjcb9GlQhC7BgBCEIAEIQgBFzPFLKYxLxlPl5qJOlZKVkWm2SXHinVwwwBwjy6romFiLjObRBzmdN3Rcf7vpWc9jXPje0HKN3il2l2jw7HFmfM4EzlBdB6i0+KgU+0OHcfjI/M13vCyvFOMnJJl6mnFJk3FU3OytbYfMeQ3ffBOUqLWjuj9fNdMeHAOaQQdCDIPiF0qq5Hs4rPIBI3X8N6z1ahnk8N+tjxWie2QQd4IUfDYXKwtOrtY9kko2xoujyXtrs1+dhc+GOD4J0DhcZuEzErV7be3FbGacOLUzTeWDVraYLHtjflmeYbKt8QxslpAIki4mR0VeNkUQSWsDCTJyd2TxgWnwWvDrFCKjJdeinJhcm5J9nkdPCPe6GtLiTu+p3Bb/sv2cFMtrEmQ0iZIDiRBgf09dYlaBmzWSLF3AG4noNVfbL2U6o7vAtYNTp0aOd1OXVPKtsF2RDCoPdJjuwNnh7nOe2WgWmR3jEdbT5hXr9kUDcsaLRqR9deeqmUqYa0NaIAAA6CyDSBMkSVMMSjGqTFlkcnZDr7MY5oYJa0fKzKAetpKgu2DkeHMyubva/6ED3V6hM8UX2hVOSKbG7JDg4tZENIaBF3E3N+VpJ8LLL1aZBLSNCQeo1C9BWQ2/ScKjnOu35bRbhH13rPqMaS3IuwzbdMqwrvsm8isQNCwz4EQRz/UqkVt2YIFdsjUOjkY18pHiqNO6yr9y3L+DN2hIlXoDmAhCEACSEFcX4epQAuX7kqBtB4s3MON48PqpuU8vb2VXi/iPw2gaF31VOZ1EaK5G21iLAg+v7+6y/8AFLatXC4CaJIdUqNpl41a0tc5+U6Xyhs/3HSFp6A74BjXg0ehJKpv4jVGNwFTNTbUu05HQ2Qx0vII0IbJEXCrwRVWxpPwfPVTbFcxNR1uFvbVSWdo8QBGZp5lon0sq/GVGOeTTYWN/pLs8H80CyMPRa+xe1h3ZpDT/kJg9R4rSIT9k9ocThnl9Ko4EmXAnM1/HM02PCdeBC+guytb/bMMyvGUuaMzODjwdvEXHVeA7D7PvxFf8OYY0jO8EOa1sTYixJAsvo3sthxSpZGgANytGpEDWBoddR+5rnihN8oaM5RXDErYaLi0biojpmIhXGLbmhwBnXvQ2ANbGIjjc3VZizMGR0zN0WDNh2M0QyX2cYbZNOoHF2YGdQdJA+oPmnj2epRYunrrbfbjeyk7MPdM6br+BU8BEcUHFNoiU5J8Mq8FsRtNzXZnFw4xE9IsrQCNEqFbGMYqoiNuXYIQhMQCEIQALLdpabg8OM5CBF7TvgT0WpWX7SUH5w8juwGgyD6QCPXqs+o/AsxfmUifwVc03tePldPUbx4gkeKaDV1C52/a7Rt22uT0im8OaHC4IBHQ3C7VT2aq5qAB+Ulv1HoQrdeixz3wUvaOVJVJoEJUJxQSSgohSByfP2VXiW94yd/QdIVqSqrHA5jzA++Sozr6jw7GBVykHSD99PUrO9rqzi+HfA5stmDDYE/FzlaJrI013lV+38Kx1E5rQZBiZJtB5FUQnt4LHGzxLb/ZRweXUACCSSyzY/LJuNSdI9mdl9k3k5q/daC2zS1xcCbyQYDY3idRCvsZ2rZTcQ6hUifilpDoPdIvA0BjVOYftDhK4LTDXXOWoAAbgmHXbeBabrVcqKqRebFwLKYYWM+DK3LkPddlJLiTcgggZr716PgHsbTaWhrQZeXEgNdJiS6LuI0B4cl55hg2XklzmvDYIdLRlkENA9brXbL2icgz0RJAa6wGZrfhDh82tjG5J8kY8yZO1vovnVaTZaRlygWgEAO3C19NAs85wJPeEyeXlyT2KxGcCBlGpEkgGI7s/CIiw6pkDj63Cw6jMptJdI0Y4bey2wzSWNIMQbidb85Uj8WDGXxF7cVW0e7GW3Q2UulXOWJiOWoTRnwLJE1pXSh0sUJvafEdeWgTlTFAAEXn7unUlVi7WSExUxTRzPJQqtYuMzHAcE2klk9DKPslnGngFyMY7lr9hRS4JGkpN79jbUSnY119PJUW2Md+JlbuaTfjIEH3Vo8iLrNLPnySrbfZdhgrsEISSshoNN2Rq2e3mHDxEH2C0qxXZ+qG1M3gfyn97+C2y7mhnuxJejm6iNTsEJULaUAhCEAcwoGObcHiI+/NWBTOKZLTyv5JMi3RaGi6ZWAKNjqGdjm8vZSSVHe+BefvT/Rc6T4L0eZbV7OvY85ILSJgm5M6Dl1Wbxex2zlfSAceUE3j5dbr1+tSa/4h+3RRhs1kzc8v3RDVNLkZ40zyHC4F9Hv0Kr6ea25zT4EQdN61uze2dVkNxFIOA1fSuY0uwmedpW0dg2FmUsbl0iN2igP7N4cmcg1BjTTpCaWohP8AJEKDj0yixXbku/5XD1arT8xa4MneBMIwm3do1hDcM2nNsznGwO/KBJjhI6rX08KxujR7+Up6FT8kEvrH+RtsvLKjYeExDHOfXrF8gANyhjW33AEnzK0LDIUYBSGNgJVJydktJHSELgvCZuiBXVAE0ahXCcZTlV7m+hqSOWsJT7WwkY2EPeACToBKaKohuyq2lWcHubuIbHSZPqFAUzadYOfA3WJ4n9rqESseR3JmmCqKAlM06uZxjQDXmf8ARRa1cm026QptCmGhJVFhNwNWHRx+wtxs2pmptPKPKyweGfldMSYsOZ+ythsJ3dd1HqF0NBOpV7MeqjxZboQhdkwghCEACEIQBmtoNNJ5v3XCR53Cj1Hyd/ints1Mzz/bYdRqqtuKh2R28SDxjUHmuHmklNpdWb4Rbin5JaEiVIAiVCEAEJ1lPihlQQnQnikK2xGtASoJTNV+5O2kgSs6dUTTnSkQqnJslKgT1Ib0jafFOTuTRjXLIbFVbtasRDBoRJ87BWD3ECwk9YVbjDlOd+Uv+VuoaOJ4oyv60NjX2srVDxdb5RHNdY6s7jrqZuVBWRLya0ScIxpN9dwU9Q8FTOsKa1pJAGpSy7BknA0pdm3D3Wn2C67hyafKZ9wqXDU8rQPHxKtNjfzP8T9LHwnyW7SfWaMed7kzQoSJV2zCCEIQAiaxE5XZdcpjrFk6mcTUytceAKWX4sldmVKr8VQztLd+7qrBNVmb1wJo6MHTKzCY11MhlTTc6d272Vu1wOigYmgHtynz4HiqxzKtIgNJI3QJHMRuKRSoscVI0iFRN22Yuy/W3snxttsDumd+ifcit45FslDiqaptwSMrJG+THkuTtzgz1U7kHxsuiULPu2086BoHiVxRxVd5hrjbfYD2uo3In42aCpUa0S4gD704pMNVcZJAHAawOZ4qDQwwBzOJc7eTBI6GLBWlJnK3kiLbfBEkoo7BzarpjblJnaNF3KvVFLFUHF4QvNrDUnid3MnnuU5QdoYvKMjfiI8gfqlybdvI0LvgoKtETmO7XmoLGFxtvUusS85G+J+iscBs3Ld32f0WWKbNbkorkaoskgD0VrTw7W6BFHDtboL8U6njGuyiU76BS+y1SXVAdRlPuCq3GVIYeJsu+zFQivE/E1084v5/ur8MtuaP/diTjeNs2iEIXcMAIQhACKDtafwzHj04ecKcq3bVWGRvcfQXP0VWZpY3foaH5IokhSoXFNpHfTjom1LKYqU46KuUaLYyvhlBtKjlfPH1/f76Qlpa1IPaWnQ/cqvxWzu4C2JbrukfqlLUyqXbGEkAakwuQFZYDDd8zBGUE7xJ0H1QS2JhtnE/GCOcj2+9FaUaQaA1oTrGSn2sAUqNlcpUctpDenEIViVFLbYIlCFJB018KK7CgkkkyZv1/ZSEAKGr4ZKddDdLDNEBrQI0UltPiu2sAXSsjBIRybOPwwmXiCpKYqm6mSVBFlftE2HX/Rd9nf57P8v/ABKa2i24PGVzsp+WtTP97R4EwfdZ4OssW/aL6vG1+jPQEIQvQ2csVCEJgEWe2riMzoGjbeO8/fBaFZrH4NzHTq0mx+h5rHrN2zjryW4a3ckVCELmGoEhCVCAIz2QmyJsVJrCyjqqSpl0XaKChhi5+QHQmTyCvg0DRDWAEkC51PFPUmzqFCVkykOtaAukIVxSCEIQQCF2KZToYOCZRbIbGWMJTrGQu0J1FIhuwQhCYgCoOJqgAmeMJ/F1Q1t/vgqSrVLtVnzTrgtxxvk4c8nVOYMS9g4vYPNwTStdgbPNSoHaNY4Eni4GQ0fVU4oynkSRbOSjFtmzQu4QvQ7GcqxUIQrSBFxUphwIIkHcnEijsDPY/Z5Z3m3b6jry5qCteqnG7KnvMseG7w4Ln59K19ofwaIZfEimQlc0gwQQRuKRYS85dpZRVMXApiZSyjYylQyxklSGiEAJQiMaCUrBACXKnWU4TxjYjYjKfFOBoSoVqSQtghCFIAhCEACbr1msEuP7pxU+PqF57t2jfG/f1STltQ0Y7mc4vHZxlAgTPNQ10WHNlg5piNTPKNVf7L7PEw6tYbmjU/mI06D0WeGPJmlSX+i6U4Y48ldsrZTqzp0YDc/RvE+y2uGoNY0NaIA0C6p0w0ANAAFgBYALsLtafTRwrjl+zBlyub/QVKkQtJUKhCEACEIQAIQhAEfE4ZrxDh0O8dCqfE7Kc27e8PXy3q/QVTkwQn2uR4zcejIOEWNihamrh2u+IA+/nqodTZY+VxHI3WKejkvxdlyzJ9lIGHgu6TIU9+z3jcD0P6wmHUXDVrh4FVfDKL5TG3pjcJUFCCQQhCABCF01hOgJ6CUAcoT7cI86NPjb3Uinsx29wHS6sWKb6QrlFeSAU9htnk6NDRxiPIb1bUcG1twJPE3P7eCkq+Gl8yK5ZfRGw+Da24EnidVJQlWuMVFUiptvsEIQmIBCEIAEIQgAQhCABCEIARCEIAVIlQgBEIQoZI1V0VXitClQseYtgVrdVa0NAhCz4uyyZYU04hC3R6M7FSoQrkKCEIUgIlQhAAhCEACEIQB//9k=";
 const DECIMALS: f64 = 1000000000000000000.;
-const K:f64 = 0.9999999999999762;
-const DAILY_STEP_CONVERSION_LIMIT:u32 = 10_000;
+const K: f64 = 0.9999999999999762;
+const DAILY_STEP_CONVERSION_LIMIT: u32 = 10_000;
 const DAY_IN_NANOS: u64 = 86_400_000_000_000;
 
 #[near_bindgen]
@@ -22,7 +21,7 @@ pub struct Contract {
     oracles: LookupSet<AccountId>,
     token: FungibleToken,
     steps_from_tge: U64,
-    daily_limits: LookupMap<AccountId, (u32, u64)> 
+    daily_limits: LookupMap<AccountId, (u32, u64)>,
 }
 
 #[near_bindgen]
@@ -36,61 +35,59 @@ impl Contract {
         }
         Self {
             oracles: oracles_tree,
-            token: FungibleToken::new(b"t".to_vec()),
+            token: FungibleToken::new(b"t"),
             steps_from_tge: U64::from(0),
-            daily_limits: LookupMap::new(b"l")
+            daily_limits: LookupMap::new(b"l"),
         }
     }
 
     pub fn get_steps_from_tge(&self) -> U64 {
-        return self.steps_from_tge
+        self.steps_from_tge
     }
 
     pub fn record_batch(&mut self, steps_batch: Vec<(ValidAccountId, u32)>) {
-        assert_eq!(true, self.oracles.contains(&env::predecessor_account_id()));
+        assert!(self.oracles.contains(&env::predecessor_account_id()));
         for (account_id, steps) in steps_batch.into_iter() {
             self.record(&account_id, steps);
         }
     }
 
-    #[private]
-    pub fn record(&mut self, account_id: &ValidAccountId, steps: u32) -> U128 {
+    fn record(&mut self, account_id: &ValidAccountId, steps: u32) -> U128 {
         if !self.token.accounts.contains_key(account_id.as_ref()) {
             self.token.internal_register_account(account_id.as_ref());
         }
-        let capped_steps = self.get_capped_steps(&account_id, steps);
+        let capped_steps = self.get_capped_steps(account_id, steps);
         let swt = self.formula(self.steps_from_tge, capped_steps);
-        self.token.internal_deposit(account_id.as_ref(), swt.0 as u128);
+        self.token
+            .internal_deposit(account_id.as_ref(), swt.0 as u128);
         self.steps_from_tge.0 += capped_steps as u64;
-        return swt
+        swt
     }
 
     pub fn formula(&self, steps_from_tge: U64, steps: u32) -> U128 {
-        let a:f64 = DECIMALS * (K.powf(steps as f64 + steps_from_tge.0 as f64 + 1.));
-        let b:f64 = DECIMALS * (K.powf(steps_from_tge.0 as f64 + 1.));
-        let swt:f64 = (a - b) / ( K - 1.) / 1000.;
-        let res = U128(swt as u128);
-        return res;
+        let a: f64 = DECIMALS * (K.powf(steps as f64 + steps_from_tge.0 as f64 + 1.));
+        let b: f64 = DECIMALS * (K.powf(steps_from_tge.0 as f64 + 1.));
+        let swt: f64 = (a - b) / (K - 1.) / 1000.;
+        U128(swt as u128)
     }
 
-    #[private]
-    pub fn get_capped_steps(&mut self, account_id: &ValidAccountId, steps_to_convert: u32) -> u32 {
-        let (mut sum, mut ts) = match self.daily_limits.get(account_id.as_ref()) {
-            Some(data) => data,
-            None => (0, 0),
-        };
-        let current_ts:u64 = env::block_timestamp();
+    fn get_capped_steps(&mut self, account_id: &ValidAccountId, steps_to_convert: u32) -> u32 {
+        let (mut sum, mut ts) = self.daily_limits.get(account_id.as_ref()).unwrap_or((0, 0));
+        let current_ts: u64 = env::block_timestamp();
         //let current_ts:u64 = env::block_timestamp() + 10; // :todo: for debug tests
         let mut remaining_steps = 2 * DAILY_STEP_CONVERSION_LIMIT;
         if ts == 0 || current_ts - ts >= DAY_IN_NANOS {
             ts = current_ts;
             sum = 0;
         }
+
+        // TODO can either variable cross u32 bounds? Cast will overflow
         remaining_steps = i32::max(0, remaining_steps as i32 - sum as i32) as u32;
-        let capped_steps:u32 = u32::min(remaining_steps, steps_to_convert);
-        self.daily_limits.insert(account_id.as_ref(), &(sum + capped_steps, ts));
+        let capped_steps: u32 = u32::min(remaining_steps, steps_to_convert);
+        self.daily_limits
+            .insert(account_id.as_ref(), &(sum + capped_steps, ts));
         // println!("time = {}, remaining_steps = {}, steps_to_convert = {}, sum = {}", current_ts, remaining_steps, steps_to_convert, sum);
-        return capped_steps;
+        capped_steps
     }
 }
 
@@ -107,48 +104,30 @@ impl FungibleTokenMetadataProvider for Contract {
             icon: Some(String::from(ICON)),
             reference: None,
             reference_hash: None,
-            decimals: 18
+            decimals: 18,
         }
     }
 }
-
 
 // :TODO: sandbox tests?
 #[cfg(test)]
 mod tests {
     use super::*;
+    use near_sdk::test_utils::VMContextBuilder;
     use near_sdk::MockedBlockchain;
     use near_sdk::{testing_env, VMContext};
     use std::convert::TryInto;
 
-    fn get_context(input: Vec<u8>, is_view: bool) -> VMContext {
-        VMContext {
-            current_account_id: "alice.testnet".to_string(),
-            signer_account_id: "robert.testnet".to_string(),
-            signer_account_pk: vec![0, 1, 2],
-            predecessor_account_id: "intmainreturn0.testnet".to_string(),
-            input,
-            block_index: 0,
-            block_timestamp: 0,
-            account_balance: 0,
-            account_locked_balance: 0,
-            storage_usage: 0,
-            attached_deposit: 0,
-            prepaid_gas: 10u64.pow(18),
-            random_seed: vec![0, 1, 2],
-            is_view,
-            output_data_receivers: vec![],
-            epoch_height: 19,
-        }
+    fn get_context(is_view: bool) -> VMContext {
+        VMContextBuilder::new().is_view(is_view).build()
     }
 
-    pub fn formula_vanila_rust(steps_from_tge: u64, steps: u32) -> u128 {
-        let a:f64 = DECIMALS * (K.powf(steps as f64 + steps_from_tge as f64 + 1.));
-        let b:f64 = DECIMALS * (K.powf(steps_from_tge as f64 + 1.));
-        let swt:f64 = (a - b) / ( K - 1.) / 1000.;
-        let res = swt as u128;
-        return res;
-    }
+    // pub fn formula_vanila_rust(steps_from_tge: u64, steps: u32) -> u128 {
+    //     let a: f64 = DECIMALS * (K.powf(steps as f64 + steps_from_tge as f64 + 1.));
+    //     let b: f64 = DECIMALS * (K.powf(steps_from_tge as f64 + 1.));
+    //     let swt: f64 = (a - b) / (K - 1.) / 1000.;
+    //     swt as u128
+    // }
 
     /*#[test]
     fn test_formula1() {
@@ -160,7 +139,7 @@ mod tests {
 
         let steps_to_convert = vec!(0, 1, 5, 500, 1_000, 2_000, 3_000, 4_000, 5_000, 6_000, 7_000, 10_000, 15_000, 17_000, 19_999, 20_000, 30_000, 40_000 );
         let steps_from_tge = vec!(0, 2_000, 10_000, 100_000, 1_000_000, 1_500_500, 2_000_000, 2_500_000, 10_000_000, 50_000_000, 1_000_000_000, 100_000_000_000u64, 1_000_000_000_000u64);
-        
+
         for tge in &steps_from_tge {
             for steps in &steps_to_convert {
                 let res_vanila: u128 = formula_vanila_rust(*tge, *steps);
@@ -183,7 +162,7 @@ mod tests {
         let steps_to_convert = vec!(0, 1, 5, 500, 1_000, 2_000, 3_000, 4_000, 5_000, 6_000, 7_000, 10_000, 15_000, 17_000, 19_999, 20_000, 30_000, 40_000 );
         let mut steps_from_tge = 0;
         let shift = 5_000_000;
-        
+
         while steps_from_tge < 1_000_000_000 {
             for steps in &steps_to_convert {
                 let res_vanila: u128 = formula_vanila_rust(steps_from_tge, *steps);
@@ -191,7 +170,7 @@ mod tests {
                 assert_eq!(res_vanila, res_contract.0);
                 let swt = res_contract.0 as f64 / DECIMALS;
                 println!("{:.1}, {:.1}, {:.10}", steps_from_tge, steps, swt);
-                steps_from_tge += shift; 
+                steps_from_tge += shift;
             }
         }
     }
@@ -227,7 +206,7 @@ mod tests {
         }
     }
 
-    
+
     #[test]
     fn test_formula4() {
         let context = get_context(vec![], false);
@@ -235,7 +214,7 @@ mod tests {
         let oracles = vec!["intmainreturn0.testnet".to_string()];
         let contract = Contract::new(oracles);
         println!("test_formula2: =====================================");
-        let steps_to_convert:u32 = 10_000;    
+        let steps_to_convert:u32 = 10_000;
         let steps_from_tge:u64 = 10000000000000 as u64;
 
         println!("{}", steps_from_tge);
@@ -256,21 +235,19 @@ mod tests {
 
     #[test]
     fn test_daily_cap1() {
-        let context = get_context(vec![], false);
+        let context = get_context(false);
         testing_env!(context);
         let oracles = vec!["intmainreturn0.testnet".to_string()];
         let mut contract = Contract::new(oracles);
         assert_eq!(U64(0), contract.get_steps_from_tge());
-        let alice:ValidAccountId = "alice.testnet".try_into().unwrap();
-        
-        let mut swt:f64 = contract.record(&alice, 10_000).0 as f64 / DECIMALS;
+        let alice: ValidAccountId = "alice.testnet".try_into().unwrap();
+
+        let mut swt: f64 = contract.record(&alice, 10_000).0 as f64 / DECIMALS;
         assert_eq!(10_000, contract.get_steps_from_tge().0);
         swt += contract.record(&alice, 30_000).0 as f64 / DECIMALS;
         swt += contract.record(&alice, 30_000).0 as f64 / DECIMALS;
         swt += contract.record(&alice, 30_000).0 as f64 / DECIMALS;
         // println!("{} much coins = {:.1}", if swt > 0.01 {"🪙"} else {"⛔️"}, swt);
         assert_eq!(20_000, contract.get_steps_from_tge().0);
-
     }
 }
-

--- a/swt/src/lib.rs
+++ b/swt/src/lib.rs
@@ -176,7 +176,7 @@ mod tests {
         testing_env!(context);
         println!("test_formula2: =====================================");
         {
-            let alice:AccountId = "alice.testnet".try_into().unwrap();
+            let alice:AccountId = "alice.testnet".parse().unwrap();
             let steps_from_tge = vec!(0, 2_000, 10_000, 100_000, 1_000_000, 1_500_500, 2_000_000, 2_500_000, 10_000_000, 50_000_000, 1_000_000_000, 1_000_000_000_000_000_000, 1_000_000_000_000_000_000_000u128);
             for tge in steps_from_tge {
                 let oracles = vec!["intmainreturn0.testnet".to_string()];


### PR DESCRIPTION
Didn't change anything logically, except for what seemed to be misuse of the `#[private]` annotation, just cleaned up some things syntactically and formatted

As for the `#[private]` annotation, this should only be used when a contract wants a method exposed but only callable by itself in an asynchronous manner. In your use case you are calling the function synchronously.